### PR TITLE
Add serialization option support

### DIFF
--- a/nunaserver/nunaserver/generator.py
+++ b/nunaserver/nunaserver/generator.py
@@ -50,7 +50,9 @@ def generate_dsdl(
     inner = [d for d in Path(arch_dir).iterdir() if d.is_dir()]
     namespaces = []
     for path in inner:
-        subnss = [d for d in path.iterdir() if d.is_dir() and not d.name.startswith(".")]
+        subnss = [
+            d for d in path.iterdir() if d.is_dir() and not d.name.startswith(".")
+        ]
         if len(subnss) > 0:
             namespaces.extend(
                 [d for d in path.iterdir() if d.is_dir() and not d.name.startswith(".")]
@@ -124,8 +126,9 @@ def generate_dsdl(
         )
         lang_context = LanguageContext(
             target_lang,
-            omit_serialization_support_for_target=False,
-            language_options=language_options
+            omit_serialization_support_for_target="--omit-serialization-support"
+            in flags,
+            language_options=language_options,
         )
 
         # Build namespace tree

--- a/nunaserver/nunaserver/generator.py
+++ b/nunaserver/nunaserver/generator.py
@@ -122,7 +122,11 @@ def generate_dsdl(
         language_options["enable_serialization_asserts"] = (
             "--enable-serialization-asserts" in flags
         )
-        lang_context = LanguageContext(target_lang)
+        lang_context = LanguageContext(
+            target_lang,
+            omit_serialization_support_for_target=False,
+            language_options=language_options
+        )
 
         # Build namespace tree
         root_namespace = build_namespace_tree(

--- a/nunaweb/services/dataOptions.js
+++ b/nunaweb/services/dataOptions.js
@@ -38,6 +38,12 @@ export const flags = [
     value: true
   },
   {
+    name: 'Omit serialization support',
+    flag: '--omit-serialization-support',
+    description: 'If provided then the types generated will be POD datatypes with no additional logic. By default types generated include serialization routines and additional support libraries, headers, or methods.',
+    value: false
+  },
+  {
     name: 'Omit float serialization support',
     flag: '--omit-float-serialization-support',
     description: 'Instruct support header generators to omit support for floating point operations in serialization routines. This will result in errors if floating point types are used, however; if you are working on a platform without IEEE754 support and do not use floating point types in your message definitions this option will avoid dead code or compiler errors in generated serialization logic.',


### PR DESCRIPTION
Due to unseen bugs, the nunaweb application did not previously generate serialization support code. This fixes that issue by adding an option for serialization.