### PR TITLE
Added port 80 to nginx configuration

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -5,6 +5,7 @@ services:
     image: uavcan/nunaweb-proxy:latest
     restart: always
     ports:
+      - "80:80"
       - "443:443"
     volumes:
       - /etc/letsencrypt/:/etc/letsencrypt

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -11,7 +11,21 @@ upstream minio {
 }
 
 server {
+    listen 80;
+    server_name nunaweb.uavcan.org;
+
+    location / {
+        return 301 https://nunaweb.uavcan.org$request_uri;
+    }
+
+    location /.well-known/acme-challenge/ {
+        root /etc/letsencrypt/webroot;
+    }
+}
+
+server {
     listen 443 ssl;
+    server_name nunaweb.uavcan.org;
 
     ssl_certificate /etc/letsencrypt/live/nunaweb.uavcan.org/cert.pem;
     ssl_certificate_key /etc/letsencrypt/live/nunaweb.uavcan.org/privkey.pem;


### PR DESCRIPTION
The changes allow the nginx to redirect all requests to port 80 to port 443 except for those needed for the challenge to renew the the Let's Encrypt certificate.  The certbot challenge plugin on the host has been changed from 'standalone' to 'webroot' per Edwin's suggestion.