### PR TITLE
Add blurb describing nunaweb to bottom of page

### DIFF
--- a/nunaweb/components/Description.vue
+++ b/nunaweb/components/Description.vue
@@ -1,0 +1,25 @@
+<template>
+  <div style="text-align: left; padding: 1rem 0;">
+    <h4>What is nunaweb?</h4>
+    <p>
+      Nunaweb is a web code generation tool for
+      <a href="https://uavcan.org">UAVCAN</a>
+      DSDL namespaces. It is based on the
+      <a href="https://github.com/UAVCAN/nunavut">
+        Nunavut transpiler
+      </a>,
+      and shows users the equivalent Nunavut commands used
+      to generate the namespace code. It is intended to be
+      an easy-to-use tool to learn about how to generate code
+      from DSDL namespaces, or as a handy one-off namespace
+      generator. Upload a DSDL namespace as a .zip (namespace directories
+      should be nested under the top-level archive directory) or provide
+      a Github link to get started!
+    </p>
+  </div>
+</template>
+
+<script>
+export default {
+}
+</script>

--- a/nunaweb/pages/index.vue
+++ b/nunaweb/pages/index.vue
@@ -157,6 +157,7 @@
             </div>
           </div>
         </div>
+        <Description />
       </form>
     </div>
     <footer class="container-fluid footer">


### PR DESCRIPTION
Adds a blurb describing what nunaweb does.

![image](https://user-images.githubusercontent.com/35390537/109267722-e1293d80-77be-11eb-99bb-0c1ea1c49fc3.png)

Should we link the UAVCAN specification doc (where DSDL is defined)?
