### PR TITLE
Lock requirements.txt packages and docker base images to specific versions

### DIFF
--- a/nunaserver/requirements.txt
+++ b/nunaserver/requirements.txt
@@ -1,20 +1,20 @@
 # Flask for serving (obviously) + CORS api
-flask
-flask-cors
-flask-limiter
-gunicorn
+flask==2.0.1
+flask-cors==3.0.10
+flask-limiter==1.4
+gunicorn==20.1.0
 
 # Requests for downloading external repos
-requests
+requests==2.25.1
 
 # Celery
-celery
-redis
+celery==5.1.0
+redis==3.5.3
 
 # Nunavut
-nunavut
-pydsdl
+nunavut==1.2.1
+pydsdl==1.12.0
 
 # MinIO
-minio
-flask-minio
+minio==7.0.3
+flask-minio==0.1.2

--- a/nunaweb/Dockerfile
+++ b/nunaweb/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:12-slim
 EXPOSE 8080
 COPY . /nunaweb
 WORKDIR /nunaweb


### PR DESCRIPTION
Freeze package versions to prevent regressions and allow controlled upgrades.