### PR TITLE
Fix MinIO file content types to be correct

### DIFF
--- a/nunaserver/nunaserver/generator.py
+++ b/nunaserver/nunaserver/generator.py
@@ -186,7 +186,7 @@ def generate_dsdl(
                     "docs",
                     str(rel_path),
                     str(file.absolute()),
-                    os.stat(file.absolute()).st_size,
+                    content_type="text/html"
                 )
         return {
             "current": len(namespaces),
@@ -210,7 +210,6 @@ def generate_dsdl(
             "results",
             zipfile_name,
             f"/tmp/{zipfile_name}",
-            os.stat(f"/tmp/{zipfile_name}").st_size,
         )
 
         return {


### PR DESCRIPTION
Previous bug (due to possible minio python API change) set the content type to the size of the file, resulting in all files being treated as plaintext.