### PR TITLE
Update minio to SNSD mode (#48)

### DIFF
--- a/nunaserver/docker-compose.yml
+++ b/nunaserver/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - FLASK_ENV=development
     command: "bash -c 'cd /nunaserver && pip3 install -r requirements.txt && python3 -m nunaserver'"
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio
     volumes:
       - ./data:/data
     network_mode: host
@@ -43,7 +43,7 @@ services:
       # CHANGE THIS
       MINIO_ROOT_USER: nunaweb
       MINIO_ROOT_PASSWORD: supersecurepassword
-    command: server /data
+    command: server /data --console-address ":9090"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s

--- a/nunaserver/nunaserver/generator.py
+++ b/nunaserver/nunaserver/generator.py
@@ -10,8 +10,7 @@ import minio
 import typing
 from typing import List
 from pathlib import Path
-from pydsdl import read_namespace
-from pydsdl._error import InvalidDefinitionError
+from pydsdl import read_namespace, InvalidDefinitionError
 from nunavut import build_namespace_tree
 from nunavut import DSDLCodeGenerator, SupportGenerator, AbstractGenerator, Namespace
 from nunaserver import settings

--- a/nunaserver/nunaserver/generator.py
+++ b/nunaserver/nunaserver/generator.py
@@ -7,12 +7,13 @@ import os
 import tempfile
 import zipfile
 import minio
+import typing
 from typing import List
 from pathlib import Path
 from pydsdl import read_namespace
 from pydsdl._error import InvalidDefinitionError
 from nunavut import build_namespace_tree
-from nunavut._generators import create_default_generators
+from nunavut import DSDLCodeGenerator, SupportGenerator, AbstractGenerator, Namespace
 from nunaserver import settings
 from nunaserver.tasks import celery
 from nunaserver.logging import init_logging
@@ -29,6 +30,8 @@ from nunavut.lang import (
 
 init_logging()
 
+def create_default_generators(ns: Namespace, **kwargs: typing.Any) -> tuple[AbstractGenerator, AbstractGenerator]:
+    return DSDLCodeGenerator(ns, **kwargs), SupportGenerator(ns, **kwargs)
 
 # pylint: disable=too-many-locals,too-many-arguments
 @celery.task(bind=True)

--- a/nunaserver/nunaserver/generator.py
+++ b/nunaserver/nunaserver/generator.py
@@ -7,12 +7,12 @@ import os
 import tempfile
 import zipfile
 import minio
-import typing
 from typing import List
 from pathlib import Path
-from pydsdl import read_namespace, InvalidDefinitionError
+from pydsdl import read_namespace
+from pydsdl._error import InvalidDefinitionError
 from nunavut import build_namespace_tree
-from nunavut import DSDLCodeGenerator, SupportGenerator, AbstractGenerator, Namespace
+from nunavut._generators import create_default_generators
 from nunaserver import settings
 from nunaserver.tasks import celery
 from nunaserver.logging import init_logging
@@ -29,8 +29,6 @@ from nunavut.lang import (
 
 init_logging()
 
-def create_default_generators(ns: Namespace, **kwargs: typing.Any) -> tuple[AbstractGenerator, AbstractGenerator]:
-    return DSDLCodeGenerator(ns, **kwargs), SupportGenerator(ns, **kwargs)
 
 # pylint: disable=too-many-locals,too-many-arguments
 @celery.task(bind=True)


### PR DESCRIPTION
Since we are only using container, the latest minIO container already deploys a SNSD minIO server. See here in documentation https://min.io/docs/minio/container/index.html.

I updated the image to closer match the one from documentation.

